### PR TITLE
Fixing a problem where co-teachers had the same priority level caused the section to be extracted twice.

### DIFF
--- a/Clever PowerQuery Support/plugin.xml
+++ b/Clever PowerQuery Support/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://plugin.powerschool.pearson.com"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     description="Clever PowerQuery Support" name="GDM - Clever Support (PQ)" 
-    version="23.10.17.01"
+    version="23.11.03.01"
     xsi:schemaLocation="http://plugin.powerschool.pearson.com plugin.xsd">
     <publisher name="Gregory Matyola">
         <contact email="greg.matyola@hanovertwpschools.org"/>

--- a/Clever PowerQuery Support/queries_root/sections_csv.named_queries.xml
+++ b/Clever PowerQuery Support/queries_root/sections_csv.named_queries.xml
@@ -83,7 +83,7 @@ My_Teachers AS (
 	FROM
 		schoolstaff
 		INNER JOIN users ON schoolstaff.users_dcid = users.dcid
-		/* teachers *.
+		/* teachers */
 		 
 		 /* 	WHERE
 		 teachers.status = 1
@@ -112,7 +112,19 @@ My_SectionTeachers AS (
 		sectionteacher.start_date,
 		sectionteacher.end_date,
 		sectionteacher.allocation,
-		COALESCE(sectionteacher.priorityorder, 1) AS priorityorder,
+		CASE
+			WHEN sectionteacher.roleId = (
+				SELECT
+					roleId
+				FROM
+					LEADROLE
+			) THEN 1
+			ELSE ROW_NUMBER() OVER (
+				PARTITION BY Sections.ID
+				ORDER BY
+					NULL
+			)
+		END AS PriorityOrder,
 		sectionteacher.notes,
 		sectionteacher.sectionnickname
 	FROM
@@ -129,7 +141,7 @@ My_SectionTeachers AS (
 		)
 )
 SELECT
-	PT.sectionid "section.id",
+	PT.sectionid "sections_id",
 	PT.course_number,
 	PT.schoolid,
 	/* 	PrTT.id "teacher_id", */
@@ -331,9 +343,9 @@ WHERE
 		'Team Planning 7',
 		'Team Planning 8'
 	)
-	 /* Ignore the staff-scheduling courses, but not the student ones! */
+	/* Ignore the staff-scheduling courses, but not the student ones! */
 	/* , */
-	 /* 			'Lunch',
+	/* 			'Lunch',
 	 'Lunch 6',
 	 'Lunch 7',
 	 'Lunch 8',
@@ -341,7 +353,7 @@ WHERE
 	 'Study 7',
 	 'Study 8',
 	 'Study Hall' 
-	*/
+	 */
 	/* The below filters out the sections without students... */
 	AND abs(PT.sectionid) IN (
 		SELECT
@@ -362,7 +374,8 @@ WHERE
 					Preferred_Range
 			)
 	)
-
+	/* AND Co_1.priorityorder = 1
+	OR sections.id IN (29921) */
 ORDER BY
 	PT.sectionid ASC,
 	CoTT_1.users_dcid DESC,

--- a/Clever PowerQuery Support/queries_root/sections_csv.named_queries.xml
+++ b/Clever PowerQuery Support/queries_root/sections_csv.named_queries.xml
@@ -374,8 +374,7 @@ WHERE
 					Preferred_Range
 			)
 	)
-	/* AND Co_1.priorityorder = 1
-	OR sections.id IN (29921) */
+
 ORDER BY
 	PT.sectionid ASC,
 	CoTT_1.users_dcid DESC,


### PR DESCRIPTION
Fix an error where co-teachers would be both at "priorityOrder" 1, and so the section would get duplicated in the push over to Clever.